### PR TITLE
feat: Add additional `updatedAtBeginTime`, `updatedAtEndTime`, and `sortField` query parameters to `listPaymentRefunds` endpoint.

### DIFF
--- a/Square/Apis/IRefundsApi.cs
+++ b/Square/Apis/IRefundsApi.cs
@@ -27,6 +27,9 @@ namespace Square.Apis
         /// </summary>
         /// <param name="beginTime">Optional parameter: Indicates the start of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `created_at` field for each `PaymentRefund`.   Default: The current time minus one year..</param>
         /// <param name="endTime">Optional parameter: Indicates the end of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `created_at` field for each `PaymentRefund`.  Default: The current time..</param>
+        /// <param name="updatedAtBeginTime">Optional parameter: Indicates the start of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `updated_at` field for each `PaymentRefund`.  Default: if omitted, the time range starts at `beginTime`..</param>
+        /// <param name="updatedAtEndTime">Optional parameter: Indicates the end of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `updated_at` field for each `PaymentRefund`.  Default: The current time..</param>
+        /// <param name="sortField">Optional parameter: The field used to sort results by. The default is `CREATED_AT`. Current values include `CREATED_AT` and `UPDATED_AT`..</param>
         /// <param name="sortOrder">Optional parameter: The order in which results are listed by `PaymentRefund.created_at`: - `ASC` - Oldest to newest. - `DESC` - Newest to oldest (default)..</param>
         /// <param name="cursor">Optional parameter: A pagination cursor returned by a previous call to this endpoint. Provide this cursor to retrieve the next set of results for the original query.  For more information, see [Pagination](https://developer.squareup.com/docs/build-basics/common-api-patterns/pagination)..</param>
         /// <param name="locationId">Optional parameter: Limit results to the location supplied. By default, results are returned for all locations associated with the seller..</param>
@@ -37,6 +40,9 @@ namespace Square.Apis
         Models.ListPaymentRefundsResponse ListPaymentRefunds(
                 string beginTime = null,
                 string endTime = null,
+                string updatedAtBeginTime = null,
+                string updatedAtEndTime = null,
+                string sortField = null,
                 string sortOrder = null,
                 string cursor = null,
                 string locationId = null,
@@ -52,6 +58,9 @@ namespace Square.Apis
         /// </summary>
         /// <param name="beginTime">Optional parameter: Indicates the start of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `created_at` field for each `PaymentRefund`.   Default: The current time minus one year..</param>
         /// <param name="endTime">Optional parameter: Indicates the end of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `created_at` field for each `PaymentRefund`.  Default: The current time..</param>
+        /// <param name="updatedAtBeginTime">Optional parameter: Indicates the start of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `updated_at` field for each `PaymentRefund`.  Default: if omitted, the time range starts at `beginTime`..</param>
+        /// <param name="updatedAtEndTime">Optional parameter: Indicates the end of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `updated_at` field for each `PaymentRefund`.  Default: The current time..</param>
+        /// <param name="sortField">Optional parameter: The field used to sort results by. The default is `CREATED_AT`. Current values include `CREATED_AT` and `UPDATED_AT`..</param>
         /// <param name="sortOrder">Optional parameter: The order in which results are listed by `PaymentRefund.created_at`: - `ASC` - Oldest to newest. - `DESC` - Newest to oldest (default)..</param>
         /// <param name="cursor">Optional parameter: A pagination cursor returned by a previous call to this endpoint. Provide this cursor to retrieve the next set of results for the original query.  For more information, see [Pagination](https://developer.squareup.com/docs/build-basics/common-api-patterns/pagination)..</param>
         /// <param name="locationId">Optional parameter: Limit results to the location supplied. By default, results are returned for all locations associated with the seller..</param>
@@ -63,6 +72,9 @@ namespace Square.Apis
         Task<Models.ListPaymentRefundsResponse> ListPaymentRefundsAsync(
                 string beginTime = null,
                 string endTime = null,
+                string updatedAtBeginTime = null,
+                string updatedAtEndTime = null,
+                string sortField = null,
                 string sortOrder = null,
                 string cursor = null,
                 string locationId = null,

--- a/Square/Apis/IRefundsApi.cs
+++ b/Square/Apis/IRefundsApi.cs
@@ -27,28 +27,28 @@ namespace Square.Apis
         /// </summary>
         /// <param name="beginTime">Optional parameter: Indicates the start of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `created_at` field for each `PaymentRefund`.   Default: The current time minus one year..</param>
         /// <param name="endTime">Optional parameter: Indicates the end of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `created_at` field for each `PaymentRefund`.  Default: The current time..</param>
-        /// <param name="updatedAtBeginTime">Optional parameter: Indicates the start of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `updated_at` field for each `PaymentRefund`.  Default: if omitted, the time range starts at `beginTime`..</param>
-        /// <param name="updatedAtEndTime">Optional parameter: Indicates the end of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `updated_at` field for each `PaymentRefund`.  Default: The current time..</param>
-        /// <param name="sortField">Optional parameter: The field used to sort results by. The default is `CREATED_AT`. Current values include `CREATED_AT` and `UPDATED_AT`..</param>
         /// <param name="sortOrder">Optional parameter: The order in which results are listed by `PaymentRefund.created_at`: - `ASC` - Oldest to newest. - `DESC` - Newest to oldest (default)..</param>
         /// <param name="cursor">Optional parameter: A pagination cursor returned by a previous call to this endpoint. Provide this cursor to retrieve the next set of results for the original query.  For more information, see [Pagination](https://developer.squareup.com/docs/build-basics/common-api-patterns/pagination)..</param>
         /// <param name="locationId">Optional parameter: Limit results to the location supplied. By default, results are returned for all locations associated with the seller..</param>
         /// <param name="status">Optional parameter: If provided, only refunds with the given status are returned. For a list of refund status values, see [PaymentRefund](entity:PaymentRefund).  Default: If omitted, refunds are returned regardless of their status..</param>
         /// <param name="sourceType">Optional parameter: If provided, only returns refunds whose payments have the indicated source type. Current values include `CARD`, `BANK_ACCOUNT`, `WALLET`, `CASH`, and `EXTERNAL`. For information about these payment source types, see [Take Payments](https://developer.squareup.com/docs/payments-api/take-payments).  Default: If omitted, refunds are returned regardless of the source type..</param>
         /// <param name="limit">Optional parameter: The maximum number of results to be returned in a single page.  It is possible to receive fewer results than the specified limit on a given page.  If the supplied value is greater than 100, no more than 100 results are returned.  Default: 100.</param>
+        /// <param name="updatedAtBeginTime">Optional parameter: Indicates the start of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `updated_at` field for each `PaymentRefund`.  Default: if omitted, the time range starts at `beginTime`..</param>
+        /// <param name="updatedAtEndTime">Optional parameter: Indicates the end of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `updated_at` field for each `PaymentRefund`.  Default: The current time..</param>
+        /// <param name="sortField">Optional parameter: The field used to sort results by. The default is `CREATED_AT`. Current values include `CREATED_AT` and `UPDATED_AT`..</param>
         /// <returns>Returns the Models.ListPaymentRefundsResponse response from the API call.</returns>
         Models.ListPaymentRefundsResponse ListPaymentRefunds(
                 string beginTime = null,
                 string endTime = null,
-                string updatedAtBeginTime = null,
-                string updatedAtEndTime = null,
-                string sortField = null,
                 string sortOrder = null,
                 string cursor = null,
                 string locationId = null,
                 string status = null,
                 string sourceType = null,
-                int? limit = null);
+                int? limit = null,
+                string updatedAtBeginTime = null,
+                string updatedAtEndTime = null,
+                string sortField = null);
 
         /// <summary>
         /// Retrieves a list of refunds for the account making the request.
@@ -58,29 +58,29 @@ namespace Square.Apis
         /// </summary>
         /// <param name="beginTime">Optional parameter: Indicates the start of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `created_at` field for each `PaymentRefund`.   Default: The current time minus one year..</param>
         /// <param name="endTime">Optional parameter: Indicates the end of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `created_at` field for each `PaymentRefund`.  Default: The current time..</param>
-        /// <param name="updatedAtBeginTime">Optional parameter: Indicates the start of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `updated_at` field for each `PaymentRefund`.  Default: if omitted, the time range starts at `beginTime`..</param>
-        /// <param name="updatedAtEndTime">Optional parameter: Indicates the end of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `updated_at` field for each `PaymentRefund`.  Default: The current time..</param>
-        /// <param name="sortField">Optional parameter: The field used to sort results by. The default is `CREATED_AT`. Current values include `CREATED_AT` and `UPDATED_AT`..</param>
         /// <param name="sortOrder">Optional parameter: The order in which results are listed by `PaymentRefund.created_at`: - `ASC` - Oldest to newest. - `DESC` - Newest to oldest (default)..</param>
         /// <param name="cursor">Optional parameter: A pagination cursor returned by a previous call to this endpoint. Provide this cursor to retrieve the next set of results for the original query.  For more information, see [Pagination](https://developer.squareup.com/docs/build-basics/common-api-patterns/pagination)..</param>
         /// <param name="locationId">Optional parameter: Limit results to the location supplied. By default, results are returned for all locations associated with the seller..</param>
         /// <param name="status">Optional parameter: If provided, only refunds with the given status are returned. For a list of refund status values, see [PaymentRefund](entity:PaymentRefund).  Default: If omitted, refunds are returned regardless of their status..</param>
         /// <param name="sourceType">Optional parameter: If provided, only returns refunds whose payments have the indicated source type. Current values include `CARD`, `BANK_ACCOUNT`, `WALLET`, `CASH`, and `EXTERNAL`. For information about these payment source types, see [Take Payments](https://developer.squareup.com/docs/payments-api/take-payments).  Default: If omitted, refunds are returned regardless of the source type..</param>
         /// <param name="limit">Optional parameter: The maximum number of results to be returned in a single page.  It is possible to receive fewer results than the specified limit on a given page.  If the supplied value is greater than 100, no more than 100 results are returned.  Default: 100.</param>
+        /// <param name="updatedAtBeginTime">Optional parameter: Indicates the start of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `updated_at` field for each `PaymentRefund`.  Default: if omitted, the time range starts at `beginTime`..</param>
+        /// <param name="updatedAtEndTime">Optional parameter: Indicates the end of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `updated_at` field for each `PaymentRefund`.  Default: The current time..</param>
+        /// <param name="sortField">Optional parameter: The field used to sort results by. The default is `CREATED_AT`. Current values include `CREATED_AT` and `UPDATED_AT`..</param>
         /// <param name="cancellationToken"> cancellationToken. </param>
         /// <returns>Returns the Models.ListPaymentRefundsResponse response from the API call.</returns>
         Task<Models.ListPaymentRefundsResponse> ListPaymentRefundsAsync(
                 string beginTime = null,
                 string endTime = null,
-                string updatedAtBeginTime = null,
-                string updatedAtEndTime = null,
-                string sortField = null,
                 string sortOrder = null,
                 string cursor = null,
                 string locationId = null,
                 string status = null,
                 string sourceType = null,
                 int? limit = null,
+                string updatedAtBeginTime = null,
+                string updatedAtEndTime = null,
+                string sortField = null,
                 CancellationToken cancellationToken = default);
 
         /// <summary>

--- a/Square/Apis/RefundsApi.cs
+++ b/Square/Apis/RefundsApi.cs
@@ -37,29 +37,29 @@ namespace Square.Apis
         /// </summary>
         /// <param name="beginTime">Optional parameter: Indicates the start of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `created_at` field for each `PaymentRefund`.   Default: The current time minus one year..</param>
         /// <param name="endTime">Optional parameter: Indicates the end of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `created_at` field for each `PaymentRefund`.  Default: The current time..</param>
-        /// <param name="updatedAtBeginTime">Optional parameter: Indicates the start of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `updated_at` field for each `PaymentRefund`.  Default: if omitted, the time range starts at `beginTime`..</param>
-        /// <param name="updatedAtEndTime">Optional parameter: Indicates the end of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `updated_at` field for each `PaymentRefund`.  Default: The current time..</param>
-        /// <param name="sortField">Optional parameter: The field used to sort results by. The default is `CREATED_AT`. Current values include `CREATED_AT` and `UPDATED_AT`..</param>
         /// <param name="sortOrder">Optional parameter: The order in which results are listed by `PaymentRefund.created_at`: - `ASC` - Oldest to newest. - `DESC` - Newest to oldest (default)..</param>
         /// <param name="cursor">Optional parameter: A pagination cursor returned by a previous call to this endpoint. Provide this cursor to retrieve the next set of results for the original query.  For more information, see [Pagination](https://developer.squareup.com/docs/build-basics/common-api-patterns/pagination)..</param>
         /// <param name="locationId">Optional parameter: Limit results to the location supplied. By default, results are returned for all locations associated with the seller..</param>
         /// <param name="status">Optional parameter: If provided, only refunds with the given status are returned. For a list of refund status values, see [PaymentRefund](entity:PaymentRefund).  Default: If omitted, refunds are returned regardless of their status..</param>
         /// <param name="sourceType">Optional parameter: If provided, only returns refunds whose payments have the indicated source type. Current values include `CARD`, `BANK_ACCOUNT`, `WALLET`, `CASH`, and `EXTERNAL`. For information about these payment source types, see [Take Payments](https://developer.squareup.com/docs/payments-api/take-payments).  Default: If omitted, refunds are returned regardless of the source type..</param>
         /// <param name="limit">Optional parameter: The maximum number of results to be returned in a single page.  It is possible to receive fewer results than the specified limit on a given page.  If the supplied value is greater than 100, no more than 100 results are returned.  Default: 100.</param>
+        /// <param name="updatedAtBeginTime">Optional parameter: Indicates the start of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `updated_at` field for each `PaymentRefund`.  Default: if omitted, the time range starts at `beginTime`..</param>
+        /// <param name="updatedAtEndTime">Optional parameter: Indicates the end of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `updated_at` field for each `PaymentRefund`.  Default: The current time..</param>
+        /// <param name="sortField">Optional parameter: The field used to sort results by. The default is `CREATED_AT`. Current values include `CREATED_AT` and `UPDATED_AT`..</param>
         /// <returns>Returns the Models.ListPaymentRefundsResponse response from the API call.</returns>
         public Models.ListPaymentRefundsResponse ListPaymentRefunds(
                 string beginTime = null,
                 string endTime = null,
-                string updatedAtBeginTime = null,
-                string updatedAtEndTime = null,
-                string sortField = null,
                 string sortOrder = null,
                 string cursor = null,
                 string locationId = null,
                 string status = null,
                 string sourceType = null,
-                int? limit = null)
-            => CoreHelper.RunTask(ListPaymentRefundsAsync(beginTime, endTime, updatedAtBeginTime, updatedAtEndTime, sortField, sortOrder, cursor, locationId, status, sourceType, limit));
+                int? limit = null,
+                string updatedAtBeginTime = null,
+                string updatedAtEndTime = null,
+                string sortField = null)
+            => CoreHelper.RunTask(ListPaymentRefundsAsync(beginTime, endTime, sortOrder, cursor, locationId, status, sourceType, limit, updatedAtBeginTime, updatedAtEndTime, sortField));
 
         /// <summary>
         /// Retrieves a list of refunds for the account making the request.
@@ -69,29 +69,29 @@ namespace Square.Apis
         /// </summary>
         /// <param name="beginTime">Optional parameter: Indicates the start of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `created_at` field for each `PaymentRefund`.   Default: The current time minus one year..</param>
         /// <param name="endTime">Optional parameter: Indicates the end of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `created_at` field for each `PaymentRefund`.  Default: The current time..</param>
-        /// <param name="updatedAtBeginTime">Optional parameter: Indicates the start of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `updated_at` field for each `PaymentRefund`.  Default: if omitted, the time range starts at `beginTime`..</param>
-        /// <param name="updatedAtEndTime">Optional parameter: Indicates the end of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `updated_at` field for each `PaymentRefund`.  Default: The current time..</param>
-        /// <param name="sortField">Optional parameter: The field used to sort results by. The default is `CREATED_AT`. Current values include `CREATED_AT` and `UPDATED_AT`..</param>
         /// <param name="sortOrder">Optional parameter: The order in which results are listed by `PaymentRefund.created_at`: - `ASC` - Oldest to newest. - `DESC` - Newest to oldest (default)..</param>
         /// <param name="cursor">Optional parameter: A pagination cursor returned by a previous call to this endpoint. Provide this cursor to retrieve the next set of results for the original query.  For more information, see [Pagination](https://developer.squareup.com/docs/build-basics/common-api-patterns/pagination)..</param>
         /// <param name="locationId">Optional parameter: Limit results to the location supplied. By default, results are returned for all locations associated with the seller..</param>
         /// <param name="status">Optional parameter: If provided, only refunds with the given status are returned. For a list of refund status values, see [PaymentRefund](entity:PaymentRefund).  Default: If omitted, refunds are returned regardless of their status..</param>
         /// <param name="sourceType">Optional parameter: If provided, only returns refunds whose payments have the indicated source type. Current values include `CARD`, `BANK_ACCOUNT`, `WALLET`, `CASH`, and `EXTERNAL`. For information about these payment source types, see [Take Payments](https://developer.squareup.com/docs/payments-api/take-payments).  Default: If omitted, refunds are returned regardless of the source type..</param>
         /// <param name="limit">Optional parameter: The maximum number of results to be returned in a single page.  It is possible to receive fewer results than the specified limit on a given page.  If the supplied value is greater than 100, no more than 100 results are returned.  Default: 100.</param>
+        /// <param name="updatedAtBeginTime">Optional parameter: Indicates the start of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `updated_at` field for each `PaymentRefund`.  Default: if omitted, the time range starts at `beginTime`..</param>
+        /// <param name="updatedAtEndTime">Optional parameter: Indicates the end of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `updated_at` field for each `PaymentRefund`.  Default: The current time..</param>
+        /// <param name="sortField">Optional parameter: The field used to sort results by. The default is `CREATED_AT`. Current values include `CREATED_AT` and `UPDATED_AT`..</param>
         /// <param name="cancellationToken"> cancellationToken. </param>
         /// <returns>Returns the Models.ListPaymentRefundsResponse response from the API call.</returns>
         public async Task<Models.ListPaymentRefundsResponse> ListPaymentRefundsAsync(
                 string beginTime = null,
                 string endTime = null,
-                string updatedAtBeginTime = null,
-                string updatedAtEndTime = null,
-                string sortField = null,
                 string sortOrder = null,
                 string cursor = null,
                 string locationId = null,
                 string status = null,
                 string sourceType = null,
                 int? limit = null,
+                string updatedAtBeginTime = null,
+                string updatedAtEndTime = null,
+                string sortField = null,
                 CancellationToken cancellationToken = default)
             => await CreateApiCall<Models.ListPaymentRefundsResponse>()
               .RequestBuilder(_requestBuilder => _requestBuilder
@@ -100,15 +100,15 @@ namespace Square.Apis
                   .Parameters(_parameters => _parameters
                       .Query(_query => _query.Setup("begin_time", beginTime))
                       .Query(_query => _query.Setup("end_time", endTime))
-                      .Query(_query => _query.Setup("updated_at_begin_time", updatedAtBeginTime))
-                      .Query(_query => _query.Setup("updated_at_end_time", updatedAtEndTime))
-                      .Query(_query => _query.Setup("sort_field", sortField))
                       .Query(_query => _query.Setup("sort_order", sortOrder))
                       .Query(_query => _query.Setup("cursor", cursor))
                       .Query(_query => _query.Setup("location_id", locationId))
                       .Query(_query => _query.Setup("status", status))
                       .Query(_query => _query.Setup("source_type", sourceType))
-                      .Query(_query => _query.Setup("limit", limit))))
+                      .Query(_query => _query.Setup("limit", limit))
+                      .Query(_query => _query.Setup("updated_at_begin_time", updatedAtBeginTime))
+                      .Query(_query => _query.Setup("updated_at_end_time", updatedAtEndTime))
+                      .Query(_query => _query.Setup("sort_field", sortField))))
               .ResponseHandler(_responseHandler => _responseHandler
                   .ContextAdder((_result, _context) => _result.ContextSetter(_context)))
               .ExecuteAsync(cancellationToken).ConfigureAwait(false);

--- a/Square/Apis/RefundsApi.cs
+++ b/Square/Apis/RefundsApi.cs
@@ -37,6 +37,9 @@ namespace Square.Apis
         /// </summary>
         /// <param name="beginTime">Optional parameter: Indicates the start of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `created_at` field for each `PaymentRefund`.   Default: The current time minus one year..</param>
         /// <param name="endTime">Optional parameter: Indicates the end of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `created_at` field for each `PaymentRefund`.  Default: The current time..</param>
+        /// <param name="updatedAtBeginTime">Optional parameter: Indicates the start of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `updated_at` field for each `PaymentRefund`.  Default: if omitted, the time range starts at `beginTime`..</param>
+        /// <param name="updatedAtEndTime">Optional parameter: Indicates the end of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `updated_at` field for each `PaymentRefund`.  Default: The current time..</param>
+        /// <param name="sortField">Optional parameter: The field used to sort results by. The default is `CREATED_AT`. Current values include `CREATED_AT` and `UPDATED_AT`..</param>
         /// <param name="sortOrder">Optional parameter: The order in which results are listed by `PaymentRefund.created_at`: - `ASC` - Oldest to newest. - `DESC` - Newest to oldest (default)..</param>
         /// <param name="cursor">Optional parameter: A pagination cursor returned by a previous call to this endpoint. Provide this cursor to retrieve the next set of results for the original query.  For more information, see [Pagination](https://developer.squareup.com/docs/build-basics/common-api-patterns/pagination)..</param>
         /// <param name="locationId">Optional parameter: Limit results to the location supplied. By default, results are returned for all locations associated with the seller..</param>
@@ -47,13 +50,16 @@ namespace Square.Apis
         public Models.ListPaymentRefundsResponse ListPaymentRefunds(
                 string beginTime = null,
                 string endTime = null,
+                string updatedAtBeginTime = null,
+                string updatedAtEndTime = null,
+                string sortField = null,
                 string sortOrder = null,
                 string cursor = null,
                 string locationId = null,
                 string status = null,
                 string sourceType = null,
                 int? limit = null)
-            => CoreHelper.RunTask(ListPaymentRefundsAsync(beginTime, endTime, sortOrder, cursor, locationId, status, sourceType, limit));
+            => CoreHelper.RunTask(ListPaymentRefundsAsync(beginTime, endTime, updatedAtBeginTime, updatedAtEndTime, sortField, sortOrder, cursor, locationId, status, sourceType, limit));
 
         /// <summary>
         /// Retrieves a list of refunds for the account making the request.
@@ -63,6 +69,9 @@ namespace Square.Apis
         /// </summary>
         /// <param name="beginTime">Optional parameter: Indicates the start of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `created_at` field for each `PaymentRefund`.   Default: The current time minus one year..</param>
         /// <param name="endTime">Optional parameter: Indicates the end of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `created_at` field for each `PaymentRefund`.  Default: The current time..</param>
+        /// <param name="updatedAtBeginTime">Optional parameter: Indicates the start of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `updated_at` field for each `PaymentRefund`.  Default: if omitted, the time range starts at `beginTime`..</param>
+        /// <param name="updatedAtEndTime">Optional parameter: Indicates the end of the time range to retrieve each `PaymentRefund` for, in RFC 3339  format.  The range is determined using the `updated_at` field for each `PaymentRefund`.  Default: The current time..</param>
+        /// <param name="sortField">Optional parameter: The field used to sort results by. The default is `CREATED_AT`. Current values include `CREATED_AT` and `UPDATED_AT`..</param>
         /// <param name="sortOrder">Optional parameter: The order in which results are listed by `PaymentRefund.created_at`: - `ASC` - Oldest to newest. - `DESC` - Newest to oldest (default)..</param>
         /// <param name="cursor">Optional parameter: A pagination cursor returned by a previous call to this endpoint. Provide this cursor to retrieve the next set of results for the original query.  For more information, see [Pagination](https://developer.squareup.com/docs/build-basics/common-api-patterns/pagination)..</param>
         /// <param name="locationId">Optional parameter: Limit results to the location supplied. By default, results are returned for all locations associated with the seller..</param>
@@ -74,6 +83,9 @@ namespace Square.Apis
         public async Task<Models.ListPaymentRefundsResponse> ListPaymentRefundsAsync(
                 string beginTime = null,
                 string endTime = null,
+                string updatedAtBeginTime = null,
+                string updatedAtEndTime = null,
+                string sortField = null,
                 string sortOrder = null,
                 string cursor = null,
                 string locationId = null,
@@ -88,6 +100,9 @@ namespace Square.Apis
                   .Parameters(_parameters => _parameters
                       .Query(_query => _query.Setup("begin_time", beginTime))
                       .Query(_query => _query.Setup("end_time", endTime))
+                      .Query(_query => _query.Setup("updated_at_begin_time", updatedAtBeginTime))
+                      .Query(_query => _query.Setup("updated_at_end_time", updatedAtEndTime))
+                      .Query(_query => _query.Setup("sort_field", sortField))
                       .Query(_query => _query.Setup("sort_order", sortOrder))
                       .Query(_query => _query.Setup("cursor", cursor))
                       .Query(_query => _query.Setup("location_id", locationId))

--- a/Square/Models/ListPaymentRefundsRequest.cs
+++ b/Square/Models/ListPaymentRefundsRequest.cs
@@ -24,41 +24,41 @@ namespace Square.Models
         /// </summary>
         /// <param name="beginTime">begin_time.</param>
         /// <param name="endTime">end_time.</param>
-        /// <param name="updatedAtBeginTime">updated_at_begin_time.</param>
-        /// <param name="updatedAtEndTime">updated_at_end_time.</param>
-        /// <param name="sortField">sort_field.</param>
         /// <param name="sortOrder">sort_order.</param>
         /// <param name="cursor">cursor.</param>
         /// <param name="locationId">location_id.</param>
         /// <param name="status">status.</param>
         /// <param name="sourceType">source_type.</param>
         /// <param name="limit">limit.</param>
+        /// <param name="updatedAtBeginTime">updated_at_begin_time.</param>
+        /// <param name="updatedAtEndTime">updated_at_end_time.</param>
+        /// <param name="sortField">sort_field.</param>
         public ListPaymentRefundsRequest(
             string beginTime = null,
             string endTime = null,
-            string updatedAtBeginTime = null,
-            string updatedAtEndTime = null,
-            string sortField = null,
             string sortOrder = null,
             string cursor = null,
             string locationId = null,
             string status = null,
             string sourceType = null,
-            int? limit = null)
+            int? limit = null,
+            string updatedAtBeginTime = null,
+            string updatedAtEndTime = null,
+            string sortField = null)
         {
             shouldSerialize = new Dictionary<string, bool>
             {
                 { "begin_time", false },
                 { "end_time", false },
-                { "updated_at_begin_time", false },
-                { "updated_at_end_time", false },
-                { "sort_field", false },
                 { "sort_order", false },
                 { "cursor", false },
                 { "location_id", false },
                 { "status", false },
                 { "source_type", false },
-                { "limit", false }
+                { "limit", false },
+                { "updated_at_begin_time", false },
+                { "updated_at_end_time", false },
+                { "sort_field", false }
             };
 
             if (beginTime != null)
@@ -71,24 +71,6 @@ namespace Square.Models
             {
                 shouldSerialize["end_time"] = true;
                 this.EndTime = endTime;
-            }
-
-            if (updatedAtBeginTime != null)
-            {
-                shouldSerialize["updated_at_begin_time"] = true;
-                this.UpdatedAtBeginTime = updatedAtBeginTime;
-            }
-
-            if (updatedAtEndTime != null)
-            {
-                shouldSerialize["updated_at_end_time"] = true;
-                this.UpdatedAtEndTime = updatedAtEndTime;
-            }
-
-            if (sortField != null)
-            {
-                shouldSerialize["sort_field"] = true;
-                this.SortField = sortField;
             }
 
             if (sortOrder != null)
@@ -126,34 +108,52 @@ namespace Square.Models
                 shouldSerialize["limit"] = true;
                 this.Limit = limit;
             }
+            
+            if (updatedAtBeginTime != null)
+            {
+                shouldSerialize["updated_at_begin_time"] = true;
+                this.UpdatedAtBeginTime = updatedAtBeginTime;
+            }
+
+            if (updatedAtEndTime != null)
+            {
+                shouldSerialize["updated_at_end_time"] = true;
+                this.UpdatedAtEndTime = updatedAtEndTime;
+            }
+
+            if (sortField != null)
+            {
+                shouldSerialize["sort_field"] = true;
+                this.SortField = sortField;
+            }
         }
 
         internal ListPaymentRefundsRequest(
             Dictionary<string, bool> shouldSerialize,
             string beginTime = null,
             string endTime = null,
-            string updatedAtBeginTime = null,
-            string updatedAtEndTime = null,
-            string sortField = null,
             string sortOrder = null,
             string cursor = null,
             string locationId = null,
             string status = null,
             string sourceType = null,
-            int? limit = null)
+            int? limit = null,
+            string updatedAtBeginTime = null,
+            string updatedAtEndTime = null,
+            string sortField = null)
         {
             this.shouldSerialize = shouldSerialize;
             BeginTime = beginTime;
             EndTime = endTime;
-            UpdatedAtBeginTime = updatedAtBeginTime;
-            UpdatedAtEndTime = updatedAtEndTime;
-            SortField = sortField;
             SortOrder = sortOrder;
             Cursor = cursor;
             LocationId = locationId;
             Status = status;
             SourceType = sourceType;
             Limit = limit;
+            UpdatedAtBeginTime = updatedAtBeginTime;
+            UpdatedAtEndTime = updatedAtEndTime;
+            SortField = sortField;
         }
 
         /// <summary>
@@ -171,29 +171,6 @@ namespace Square.Models
         /// </summary>
         [JsonProperty("end_time")]
         public string EndTime { get; }
-
-        /// <summary>
-        /// Indicates the start of the time range to retrieve each `PaymentRefund` for, in RFC 3339
-        /// format.  The range is determined using the `updated_at` field for each `PaymentRefund`.
-        /// Default: if omitted, the time range starts at `beginTime`.
-        /// </summary>
-        [JsonProperty("updated_at_begin_time")]
-        public string UpdatedAtBeginTime { get; }
-
-        /// <summary>
-        /// Indicates the end of the time range to retrieve each `PaymentRefund` for, in RFC 3339
-        /// format.  The range is determined using the `updated_at` field for each `PaymentRefund`.
-        /// Default: The current time.
-        /// </summary>
-        [JsonProperty("updated_at_end_time")]
-        public string UpdatedAtEndTime { get; }
-
-        /// <summary>
-        /// The field used to sort results by. The default is `CREATED_AT`.
-        /// Current values include `CREATED_AT` and `UPDATED_AT`.
-        /// </summary>
-        [JsonProperty("sort_field")]
-        public string SortField { get; }
 
         /// <summary>
         /// The order in which results are listed by `PaymentRefund.created_at`:
@@ -245,6 +222,29 @@ namespace Square.Models
         [JsonProperty("limit")]
         public int? Limit { get; }
 
+        /// <summary>
+        /// Indicates the start of the time range to retrieve each `PaymentRefund` for, in RFC 3339
+        /// format.  The range is determined using the `updated_at` field for each `PaymentRefund`.
+        /// Default: if omitted, the time range starts at `beginTime`.
+        /// </summary>
+        [JsonProperty("updated_at_begin_time")]
+        public string UpdatedAtBeginTime { get; }
+
+        /// <summary>
+        /// Indicates the end of the time range to retrieve each `PaymentRefund` for, in RFC 3339
+        /// format.  The range is determined using the `updated_at` field for each `PaymentRefund`.
+        /// Default: The current time.
+        /// </summary>
+        [JsonProperty("updated_at_end_time")]
+        public string UpdatedAtEndTime { get; }
+
+        /// <summary>
+        /// The field used to sort results by. The default is `CREATED_AT`.
+        /// Current values include `CREATED_AT` and `UPDATED_AT`.
+        /// </summary>
+        [JsonProperty("sort_field")]
+        public string SortField { get; }
+
         /// <inheritdoc/>
         public override string ToString()
         {
@@ -269,33 +269,6 @@ namespace Square.Models
         public bool ShouldSerializeEndTime()
         {
             return this.shouldSerialize["end_time"];
-        }
-
-        /// <summary> 
-        /// Checks if the field should be serialized or not.
-        /// </summary>
-        /// <returns>A boolean weather the field should be serialized or not.</returns>
-        public bool ShouldSerializeUpdatedAtBeginTime()
-        {
-            return this.shouldSerialize["updated_at_begin_time"];
-        }
-
-        /// <summary>   
-        /// Checks if the field should be serialized or not.
-        /// </summary>
-        /// <returns>A boolean weather the field should be serialized or not.</returns>
-        public bool ShouldSerializeUpdatedAtEndTime()
-        {
-            return this.shouldSerialize["updated_at_end_time"];
-        }
-
-        /// <summary>
-        /// Checks if the field should be serialized or not.
-        /// </summary>
-        /// <returns>A boolean weather the field should be serialized or not.</returns>
-        public bool ShouldSerializeSortField()
-        {
-            return this.shouldSerialize["sort_field"];
         }
 
         /// <summary>
@@ -352,6 +325,33 @@ namespace Square.Models
             return this.shouldSerialize["limit"];
         }
 
+        /// <summary> 
+        /// Checks if the field should be serialized or not.
+        /// </summary>
+        /// <returns>A boolean weather the field should be serialized or not.</returns>
+        public bool ShouldSerializeUpdatedAtBeginTime()
+        {
+            return this.shouldSerialize["updated_at_begin_time"];
+        }
+
+        /// <summary>   
+        /// Checks if the field should be serialized or not.
+        /// </summary>
+        /// <returns>A boolean weather the field should be serialized or not.</returns>
+        public bool ShouldSerializeUpdatedAtEndTime()
+        {
+            return this.shouldSerialize["updated_at_end_time"];
+        }
+
+        /// <summary>
+        /// Checks if the field should be serialized or not.
+        /// </summary>
+        /// <returns>A boolean weather the field should be serialized or not.</returns>
+        public bool ShouldSerializeSortField()
+        {
+            return this.shouldSerialize["sort_field"];
+        }
+
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
@@ -363,12 +363,6 @@ namespace Square.Models
                  this.BeginTime?.Equals(other.BeginTime) == true) &&
                 (this.EndTime == null && other.EndTime == null ||
                  this.EndTime?.Equals(other.EndTime) == true) &&
-                (this.UpdatedAtBeginTime == null && other.UpdatedAtBeginTime == null ||
-                 this.UpdatedAtBeginTime?.Equals(other.UpdatedAtBeginTime) == true) &&
-                (this.UpdatedAtEndTime == null && other.UpdatedAtEndTime == null ||
-                 this.UpdatedAtEndTime?.Equals(other.UpdatedAtEndTime) == true) &&
-                (this.SortField == null && other.SortField == null ||
-                 this.SortField?.Equals(other.SortField) == true) &&
                 (this.SortOrder == null && other.SortOrder == null ||
                  this.SortOrder?.Equals(other.SortOrder) == true) &&
                 (this.Cursor == null && other.Cursor == null ||
@@ -380,14 +374,20 @@ namespace Square.Models
                 (this.SourceType == null && other.SourceType == null ||
                  this.SourceType?.Equals(other.SourceType) == true) &&
                 (this.Limit == null && other.Limit == null ||
-                 this.Limit?.Equals(other.Limit) == true);
+                 this.Limit?.Equals(other.Limit) == true) &&
+                (this.UpdatedAtBeginTime == null && other.UpdatedAtBeginTime == null ||
+                 this.UpdatedAtBeginTime?.Equals(other.UpdatedAtBeginTime) == true) &&
+                (this.UpdatedAtEndTime == null && other.UpdatedAtEndTime == null ||
+                 this.UpdatedAtEndTime?.Equals(other.UpdatedAtEndTime) == true) &&
+                (this.SortField == null && other.SortField == null ||
+                 this.SortField?.Equals(other.SortField) == true);
         }
 
         /// <inheritdoc/>
         public override int GetHashCode()
         {
             var hashCode = -211695136;
-            hashCode = HashCode.Combine(hashCode, this.BeginTime, this.EndTime, this.SortOrder, this.Cursor, this.LocationId, this.Status, this.SourceType);
+            hashCode = HashCode.Combine(hashCode, this.BeginTime, this.EndTime, this.SortOrder, this.Cursor, this.LocationId, this.Status, this.SourceType, this.UpdatedAtBeginTime, this.UpdatedAtEndTime, this.SortField);
 
             hashCode = HashCode.Combine(hashCode, this.Limit);
 
@@ -408,6 +408,9 @@ namespace Square.Models
             toStringOutput.Add($"this.Status = {this.Status ?? "null"}");
             toStringOutput.Add($"this.SourceType = {this.SourceType ?? "null"}");
             toStringOutput.Add($"this.Limit = {(this.Limit == null ? "null" : this.Limit.ToString())}");
+            toStringOutput.Add($"this.UpdatedAtBeginTime = {this.UpdatedAtBeginTime ?? "null"}");
+            toStringOutput.Add($"this.UpdatedAtEndTime = {this.UpdatedAtEndTime ?? "null"}");
+            toStringOutput.Add($"this.SortField = {this.SortField ?? "null"}");
         }
 
         /// <summary>
@@ -424,7 +427,10 @@ namespace Square.Models
                 .LocationId(this.LocationId)
                 .Status(this.Status)
                 .SourceType(this.SourceType)
-                .Limit(this.Limit);
+                .Limit(this.Limit)
+                .UpdatedAtBeginTime(this.UpdatedAtBeginTime)
+                .UpdatedAtEndTime(this.UpdatedAtEndTime)
+                .SortField(this.SortField);
             return builder;
         }
 
@@ -443,6 +449,9 @@ namespace Square.Models
                 { "status", false },
                 { "source_type", false },
                 { "limit", false },
+                { "updated_at_begin_time", false },
+                { "updated_at_end_time", false },
+                { "sort_field", false },
             };
 
             private string beginTime;
@@ -453,6 +462,9 @@ namespace Square.Models
             private string status;
             private string sourceType;
             private int? limit;
+            private string updatedAtBeginTime;
+            private string updatedAtEndTime;
+            private string sortField;
 
              /// <summary>
              /// BeginTime.
@@ -550,6 +562,42 @@ namespace Square.Models
                 return this;
             }
 
+             /// <summary>
+             /// UpdatedAtBeginTime.
+             /// </summary>
+             /// <param name="updatedAtBeginTime"> updatedAtBeginTime. </param>
+             /// <returns> Builder. </returns>
+            public Builder UpdatedAtBeginTime(string updatedAtBeginTime)
+            {
+                shouldSerialize["updated_at_begin_time"] = true;
+                this.updatedAtBeginTime = updatedAtBeginTime;
+                return this;
+            }
+
+             /// <summary>
+             /// UpdatedAtEndTime.
+             /// </summary>
+             /// <param name="updatedAtEndTime"> updatedAtEndTime. </param>
+             /// <returns> Builder. </returns>
+            public Builder UpdatedAtEndTime(string updatedAtEndTime)
+            {
+                shouldSerialize["updated_at_end_time"] = true;
+                this.updatedAtEndTime = updatedAtEndTime;
+                return this;
+            }
+
+             /// <summary>
+             /// SortField.
+             /// </summary>
+             /// <param name="sortField"> sortField. </param>
+             /// <returns> Builder. </returns>
+            public Builder SortField(string sortField)
+            {
+                shouldSerialize["sort_field"] = true;
+                this.sortField = sortField;
+                return this;
+            }
+
             /// <summary>
             /// Marks the field to not be serialized.
             /// </summary>
@@ -614,6 +662,29 @@ namespace Square.Models
                 this.shouldSerialize["limit"] = false;
             }
 
+            /// <summary>   
+            /// Marks the field to not be serialized.
+            /// </summary>
+            public void UnsetUpdatedAtBeginTime()
+            {
+                this.shouldSerialize["updated_at_begin_time"] = false;
+            }
+
+            /// <summary>
+            /// Marks the field to not be serialized.
+            /// </summary>
+            public void UnsetUpdatedAtEndTime()
+            {
+                this.shouldSerialize["updated_at_end_time"] = false;
+            }
+
+            /// <summary>
+            /// Marks the field to not be serialized.
+            /// </summary>
+            public void UnsetSortField()
+            {
+                this.shouldSerialize["sort_field"] = false;
+            }
 
             /// <summary>
             /// Builds class object.
@@ -625,15 +696,15 @@ namespace Square.Models
                     shouldSerialize,
                     this.beginTime,
                     this.endTime,
-                    this.updatedAtBeginTime,
-                    this.updatedAtEndTime,
-                    this.sortField,
                     this.sortOrder,
                     this.cursor,
                     this.locationId,
                     this.status,
                     this.sourceType,
-                    this.limit);
+                    this.limit,
+                    this.updatedAtBeginTime,
+                    this.updatedAtEndTime,
+                    this.sortField);
             }
         }
     }

--- a/Square/Models/ListPaymentRefundsRequest.cs
+++ b/Square/Models/ListPaymentRefundsRequest.cs
@@ -24,6 +24,9 @@ namespace Square.Models
         /// </summary>
         /// <param name="beginTime">begin_time.</param>
         /// <param name="endTime">end_time.</param>
+        /// <param name="updatedAtBeginTime">updated_at_begin_time.</param>
+        /// <param name="updatedAtEndTime">updated_at_end_time.</param>
+        /// <param name="sortField">sort_field.</param>
         /// <param name="sortOrder">sort_order.</param>
         /// <param name="cursor">cursor.</param>
         /// <param name="locationId">location_id.</param>
@@ -33,6 +36,9 @@ namespace Square.Models
         public ListPaymentRefundsRequest(
             string beginTime = null,
             string endTime = null,
+            string updatedAtBeginTime = null,
+            string updatedAtEndTime = null,
+            string sortField = null,
             string sortOrder = null,
             string cursor = null,
             string locationId = null,
@@ -44,6 +50,9 @@ namespace Square.Models
             {
                 { "begin_time", false },
                 { "end_time", false },
+                { "updated_at_begin_time", false },
+                { "updated_at_end_time", false },
+                { "sort_field", false },
                 { "sort_order", false },
                 { "cursor", false },
                 { "location_id", false },
@@ -62,6 +71,24 @@ namespace Square.Models
             {
                 shouldSerialize["end_time"] = true;
                 this.EndTime = endTime;
+            }
+
+            if (updatedAtBeginTime != null)
+            {
+                shouldSerialize["updated_at_begin_time"] = true;
+                this.UpdatedAtBeginTime = updatedAtBeginTime;
+            }
+
+            if (updatedAtEndTime != null)
+            {
+                shouldSerialize["updated_at_end_time"] = true;
+                this.UpdatedAtEndTime = updatedAtEndTime;
+            }
+
+            if (sortField != null)
+            {
+                shouldSerialize["sort_field"] = true;
+                this.SortField = sortField;
             }
 
             if (sortOrder != null)
@@ -105,6 +132,9 @@ namespace Square.Models
             Dictionary<string, bool> shouldSerialize,
             string beginTime = null,
             string endTime = null,
+            string updatedAtBeginTime = null,
+            string updatedAtEndTime = null,
+            string sortField = null,
             string sortOrder = null,
             string cursor = null,
             string locationId = null,
@@ -115,6 +145,9 @@ namespace Square.Models
             this.shouldSerialize = shouldSerialize;
             BeginTime = beginTime;
             EndTime = endTime;
+            UpdatedAtBeginTime = updatedAtBeginTime;
+            UpdatedAtEndTime = updatedAtEndTime;
+            SortField = sortField;
             SortOrder = sortOrder;
             Cursor = cursor;
             LocationId = locationId;
@@ -138,6 +171,29 @@ namespace Square.Models
         /// </summary>
         [JsonProperty("end_time")]
         public string EndTime { get; }
+
+        /// <summary>
+        /// Indicates the start of the time range to retrieve each `PaymentRefund` for, in RFC 3339
+        /// format.  The range is determined using the `updated_at` field for each `PaymentRefund`.
+        /// Default: if omitted, the time range starts at `beginTime`.
+        /// </summary>
+        [JsonProperty("updated_at_begin_time")]
+        public string UpdatedAtBeginTime { get; }
+
+        /// <summary>
+        /// Indicates the end of the time range to retrieve each `PaymentRefund` for, in RFC 3339
+        /// format.  The range is determined using the `updated_at` field for each `PaymentRefund`.
+        /// Default: The current time.
+        /// </summary>
+        [JsonProperty("updated_at_end_time")]
+        public string UpdatedAtEndTime { get; }
+
+        /// <summary>
+        /// The field used to sort results by. The default is `CREATED_AT`.
+        /// Current values include `CREATED_AT` and `UPDATED_AT`.
+        /// </summary>
+        [JsonProperty("sort_field")]
+        public string SortField { get; }
 
         /// <summary>
         /// The order in which results are listed by `PaymentRefund.created_at`:
@@ -215,6 +271,33 @@ namespace Square.Models
             return this.shouldSerialize["end_time"];
         }
 
+        /// <summary> 
+        /// Checks if the field should be serialized or not.
+        /// </summary>
+        /// <returns>A boolean weather the field should be serialized or not.</returns>
+        public bool ShouldSerializeUpdatedAtBeginTime()
+        {
+            return this.shouldSerialize["updated_at_begin_time"];
+        }
+
+        /// <summary>   
+        /// Checks if the field should be serialized or not.
+        /// </summary>
+        /// <returns>A boolean weather the field should be serialized or not.</returns>
+        public bool ShouldSerializeUpdatedAtEndTime()
+        {
+            return this.shouldSerialize["updated_at_end_time"];
+        }
+
+        /// <summary>
+        /// Checks if the field should be serialized or not.
+        /// </summary>
+        /// <returns>A boolean weather the field should be serialized or not.</returns>
+        public bool ShouldSerializeSortField()
+        {
+            return this.shouldSerialize["sort_field"];
+        }
+
         /// <summary>
         /// Checks if the field should be serialized or not.
         /// </summary>
@@ -280,6 +363,12 @@ namespace Square.Models
                  this.BeginTime?.Equals(other.BeginTime) == true) &&
                 (this.EndTime == null && other.EndTime == null ||
                  this.EndTime?.Equals(other.EndTime) == true) &&
+                (this.UpdatedAtBeginTime == null && other.UpdatedAtBeginTime == null ||
+                 this.UpdatedAtBeginTime?.Equals(other.UpdatedAtBeginTime) == true) &&
+                (this.UpdatedAtEndTime == null && other.UpdatedAtEndTime == null ||
+                 this.UpdatedAtEndTime?.Equals(other.UpdatedAtEndTime) == true) &&
+                (this.SortField == null && other.SortField == null ||
+                 this.SortField?.Equals(other.SortField) == true) &&
                 (this.SortOrder == null && other.SortOrder == null ||
                  this.SortOrder?.Equals(other.SortOrder) == true) &&
                 (this.Cursor == null && other.Cursor == null ||
@@ -536,6 +625,9 @@ namespace Square.Models
                     shouldSerialize,
                     this.beginTime,
                     this.endTime,
+                    this.updatedAtBeginTime,
+                    this.updatedAtEndTime,
+                    this.sortField,
                     this.sortOrder,
                     this.cursor,
                     this.locationId,

--- a/Square/Square.csproj
+++ b/Square/Square.csproj
@@ -4,13 +4,13 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Square</AssemblyName>
-    <Version>40.0.0.0</Version>
+    <Version>40.1.0.0</Version>
     <Authors>Square Developer Platform</Authors>
     <Owners>Square Developer Platform</Owners>
     <Product>Square</Product>
     <Copyright>Copyright ©  2019</Copyright>
-    <AssemblyVersion>40.0.0.0</AssemblyVersion>
-    <FileVersion>40.0.0.0</FileVersion>
+    <AssemblyVersion>40.1.0.0</AssemblyVersion>
+    <FileVersion>40.1.0.0</FileVersion>
     <Description>.NET client library for the Square API</Description>
     <LangVersion>7.3</LangVersion>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/Square/SquareClient.cs
+++ b/Square/SquareClient.cs
@@ -42,7 +42,7 @@ namespace Square
         };
 
         private readonly GlobalConfiguration globalConfiguration;
-        private const string userAgent = "Square-DotNet-SDK/40.0.0 ({api-version}) {engine}/{engine-version} ({os-info}) {detail}";
+        private const string userAgent = "Square-DotNet-SDK/40.1.0 ({api-version}) {engine}/{engine-version} ({os-info}) {detail}";
         private readonly HttpCallback httpCallback;
         private readonly IDictionary<string, List<string>> additionalHeaders;
         private readonly Lazy<IMobileAuthorizationApi> mobileAuthorization;
@@ -427,7 +427,7 @@ namespace Square
         /// <summary>
         /// Gets the current version of the SDK.
         /// </summary>
-        public string SdkVersion => "40.0.0";
+        public string SdkVersion => "40.1.0";
 
         /// <summary>
         /// Gets the configuration of the Http Client associated with this client.

--- a/Square/SquareClient.cs
+++ b/Square/SquareClient.cs
@@ -585,7 +585,7 @@ namespace Square
         /// </summary>
         public class Builder
         {
-            private string squareVersion = "2025-01-23";
+            private string squareVersion = "2025-02-20";
             private string userAgentDetail = null;
             private Environment environment = Square.Environment.Production;
             private string customUrl = "https://connect.squareup.com";

--- a/doc/api/refunds.md
+++ b/doc/api/refunds.md
@@ -28,6 +28,9 @@ The maximum results per page is 100.
 ListPaymentRefundsAsync(
     string beginTime = null,
     string endTime = null,
+    string updatedAtBeginTime = null,
+    string updatedAtEndTime = null,
+    string sortField = null,
     string sortOrder = null,
     string cursor = null,
     string locationId = null,
@@ -42,6 +45,9 @@ ListPaymentRefundsAsync(
 |  --- | --- | --- | --- |
 | `beginTime` | `string` | Query, Optional | Indicates the start of the time range to retrieve each `PaymentRefund` for, in RFC 3339<br>format.  The range is determined using the `created_at` field for each `PaymentRefund`.<br><br>Default: The current time minus one year. |
 | `endTime` | `string` | Query, Optional | Indicates the end of the time range to retrieve each `PaymentRefund` for, in RFC 3339<br>format.  The range is determined using the `created_at` field for each `PaymentRefund`.<br><br>Default: The current time. |
+| `updatedAtBeginTime` | `string` | Query, Optional | Indicates the start of the time range to retrieve each `PaymentRefund` for, in RFC 3339<br>format.  The range is determined using the `updated_at` field for each `PaymentRefund`.<br><br>Default: if omitted, the time range starts at `beginTime`. |
+| `updatedAtEndTime` | `string` | Query, Optional | Indicates the end of the time range to retrieve each `PaymentRefund` for, in RFC 3339<br>format.  The range is determined using the `updated_at` field for each `PaymentRefund`.<br><br>Default: The current time. |
+| `sortField` | `string` | Query, Optional | The field used to sort results by. The default is `CREATED_AT`.<br>Current values include `CREATED_AT` and `UPDATED_AT`.<br> |
 | `sortOrder` | `string` | Query, Optional | The order in which results are listed by `PaymentRefund.created_at`:<br><br>- `ASC` - Oldest to newest.<br>- `DESC` - Newest to oldest (default). |
 | `cursor` | `string` | Query, Optional | A pagination cursor returned by a previous call to this endpoint.<br>Provide this cursor to retrieve the next set of results for the original query.<br><br>For more information, see [Pagination](https://developer.squareup.com/docs/build-basics/common-api-patterns/pagination). |
 | `locationId` | `string` | Query, Optional | Limit results to the location supplied. By default, results are returned<br>for all locations associated with the seller. |

--- a/doc/api/refunds.md
+++ b/doc/api/refunds.md
@@ -28,15 +28,15 @@ The maximum results per page is 100.
 ListPaymentRefundsAsync(
     string beginTime = null,
     string endTime = null,
-    string updatedAtBeginTime = null,
-    string updatedAtEndTime = null,
-    string sortField = null,
     string sortOrder = null,
     string cursor = null,
     string locationId = null,
     string status = null,
     string sourceType = null,
-    int? limit = null)
+    int? limit = null,
+    string updatedAtBeginTime = null,
+    string updatedAtEndTime = null,
+    string sortField = null)
 ```
 
 ## Parameters
@@ -45,15 +45,15 @@ ListPaymentRefundsAsync(
 |  --- | --- | --- | --- |
 | `beginTime` | `string` | Query, Optional | Indicates the start of the time range to retrieve each `PaymentRefund` for, in RFC 3339<br>format.  The range is determined using the `created_at` field for each `PaymentRefund`.<br><br>Default: The current time minus one year. |
 | `endTime` | `string` | Query, Optional | Indicates the end of the time range to retrieve each `PaymentRefund` for, in RFC 3339<br>format.  The range is determined using the `created_at` field for each `PaymentRefund`.<br><br>Default: The current time. |
-| `updatedAtBeginTime` | `string` | Query, Optional | Indicates the start of the time range to retrieve each `PaymentRefund` for, in RFC 3339<br>format.  The range is determined using the `updated_at` field for each `PaymentRefund`.<br><br>Default: if omitted, the time range starts at `beginTime`. |
-| `updatedAtEndTime` | `string` | Query, Optional | Indicates the end of the time range to retrieve each `PaymentRefund` for, in RFC 3339<br>format.  The range is determined using the `updated_at` field for each `PaymentRefund`.<br><br>Default: The current time. |
-| `sortField` | `string` | Query, Optional | The field used to sort results by. The default is `CREATED_AT`.<br>Current values include `CREATED_AT` and `UPDATED_AT`.<br> |
 | `sortOrder` | `string` | Query, Optional | The order in which results are listed by `PaymentRefund.created_at`:<br><br>- `ASC` - Oldest to newest.<br>- `DESC` - Newest to oldest (default). |
 | `cursor` | `string` | Query, Optional | A pagination cursor returned by a previous call to this endpoint.<br>Provide this cursor to retrieve the next set of results for the original query.<br><br>For more information, see [Pagination](https://developer.squareup.com/docs/build-basics/common-api-patterns/pagination). |
 | `locationId` | `string` | Query, Optional | Limit results to the location supplied. By default, results are returned<br>for all locations associated with the seller. |
 | `status` | `string` | Query, Optional | If provided, only refunds with the given status are returned.<br>For a list of refund status values, see [PaymentRefund](entity:PaymentRefund).<br><br>Default: If omitted, refunds are returned regardless of their status. |
 | `sourceType` | `string` | Query, Optional | If provided, only returns refunds whose payments have the indicated source type.<br>Current values include `CARD`, `BANK_ACCOUNT`, `WALLET`, `CASH`, and `EXTERNAL`.<br>For information about these payment source types, see<br>[Take Payments](https://developer.squareup.com/docs/payments-api/take-payments).<br><br>Default: If omitted, refunds are returned regardless of the source type. |
 | `limit` | `int?` | Query, Optional | The maximum number of results to be returned in a single page.<br><br>It is possible to receive fewer results than the specified limit on a given page.<br><br>If the supplied value is greater than 100, no more than 100 results are returned.<br><br>Default: 100 |
+| `updatedAtBeginTime` | `string` | Query, Optional | Indicates the start of the time range to retrieve each `PaymentRefund` for, in RFC 3339<br>format.  The range is determined using the `updated_at` field for each `PaymentRefund`.<br><br>Default: if omitted, the time range starts at `beginTime`. |
+| `updatedAtEndTime` | `string` | Query, Optional | Indicates the end of the time range to retrieve each `PaymentRefund` for, in RFC 3339<br>format.  The range is determined using the `updated_at` field for each `PaymentRefund`.<br><br>Default: The current time. |
+| `sortField` | `string` | Query, Optional | The field used to sort results by. The default is `CREATED_AT`.<br>Current values include `CREATED_AT` and `UPDATED_AT`.<br> |
 
 ## Response Type
 

--- a/doc/client.md
+++ b/doc/client.md
@@ -5,7 +5,7 @@ The following parameters are configurable for the API Client:
 
 | Parameter | Type | Description |
 |  --- | --- | --- |
-| `SquareVersion` | `string` | Square Connect API versions<br>*Default*: `"2025-01-23"` |
+| `SquareVersion` | `string` | Square Connect API versions<br>*Default*: `"2025-02-20"` |
 | `CustomUrl` | `string` | Sets the base URL requests are made to. Defaults to `https://connect.squareup.com`<br>*Default*: `"https://connect.squareup.com"` |
 | `Environment` | `string` | The API environment. <br> **Default: `production`** |
 | `Timeout` | `TimeSpan` | Http client timeout.<br>*Default*: `TimeSpan.FromSeconds(60)` |
@@ -21,7 +21,7 @@ SquareClient client = new SquareClient.Builder()
             "AccessToken"
         )
         .Build())
-    .SquareVersion("2025-01-23")
+    .SquareVersion("2025-02-20")
     .Environment(Square.Environment.Production)
     .CustomUrl("https://connect.squareup.com")
     .Build();
@@ -50,7 +50,7 @@ namespace TestConsoleProject
                         "AccessToken"
                     )
                     .Build())
-                .SquareVersion("2025-01-23")
+                .SquareVersion("2025-02-20")
                 .Environment(Square.Environment.Production)
                 .CustomUrl("https://connect.squareup.com")
                 .Build();

--- a/doc/models/list-payment-refunds-request.md
+++ b/doc/models/list-payment-refunds-request.md
@@ -16,15 +16,15 @@ The maximum results per page is 100.
 |  --- | --- | --- | --- |
 | `BeginTime` | `string` | Optional | Indicates the start of the time range to retrieve each `PaymentRefund` for, in RFC 3339<br>format.  The range is determined using the `created_at` field for each `PaymentRefund`.<br><br>Default: The current time minus one year. |
 | `EndTime` | `string` | Optional | Indicates the end of the time range to retrieve each `PaymentRefund` for, in RFC 3339<br>format.  The range is determined using the `created_at` field for each `PaymentRefund`.<br><br>Default: The current time. |
-| `UpdatedAtBeginTime` | `string` | Optional | Indicates the start of the time range to retrieve each `PaymentRefund` for, in RFC 3339<br>format.  The range is determined using the `updated_at` field for each `PaymentRefund`.<br><br>Default: if omitted, the time range starts at `BeginTime`. |
-| `UpdatedAtEndTime` | `string` | Optional | Indicates the end of the time range to retrieve each `PaymentRefund` for, in RFC 3339<br>format.  The range is determined using the `updated_at` field for each `PaymentRefund`.<br><br>Default: The current time. |
-| `SortField` | `string` | Optional | The field used to sort results by. The default is `CREATED_AT`.<br>Current values include `CREATED_AT` and `UPDATED_AT`.<br> |
 | `SortOrder` | `string` | Optional | The order in which results are listed by `PaymentRefund.created_at`:<br><br>- `ASC` - Oldest to newest.<br>- `DESC` - Newest to oldest (default). |
 | `Cursor` | `string` | Optional | A pagination cursor returned by a previous call to this endpoint.<br>Provide this cursor to retrieve the next set of results for the original query.<br><br>For more information, see [Pagination](https://developer.squareup.com/docs/build-basics/common-api-patterns/pagination). |
 | `LocationId` | `string` | Optional | Limit results to the location supplied. By default, results are returned<br>for all locations associated with the seller. |
 | `Status` | `string` | Optional | If provided, only refunds with the given status are returned.<br>For a list of refund status values, see [PaymentRefund](entity:PaymentRefund).<br><br>Default: If omitted, refunds are returned regardless of their status. |
 | `SourceType` | `string` | Optional | If provided, only returns refunds whose payments have the indicated source type.<br>Current values include `CARD`, `BANK_ACCOUNT`, `WALLET`, `CASH`, and `EXTERNAL`.<br>For information about these payment source types, see<br>[Take Payments](https://developer.squareup.com/docs/payments-api/take-payments).<br><br>Default: If omitted, refunds are returned regardless of the source type. |
 | `Limit` | `int?` | Optional | The maximum number of results to be returned in a single page.<br><br>It is possible to receive fewer results than the specified limit on a given page.<br><br>If the supplied value is greater than 100, no more than 100 results are returned.<br><br>Default: 100 |
+| `UpdatedAtBeginTime` | `string` | Optional | Indicates the start of the time range to retrieve each `PaymentRefund` for, in RFC 3339<br>format.  The range is determined using the `updated_at` field for each `PaymentRefund`.<br><br>Default: if omitted, the time range starts at `BeginTime`. |
+| `UpdatedAtEndTime` | `string` | Optional | Indicates the end of the time range to retrieve each `PaymentRefund` for, in RFC 3339<br>format.  The range is determined using the `updated_at` field for each `PaymentRefund`.<br><br>Default: The current time. |
+| `SortField` | `string` | Optional | The field used to sort results by. The default is `CREATED_AT`.<br>Current values include `CREATED_AT` and `UPDATED_AT`.<br> |
 
 ## Example (as JSON)
 

--- a/doc/models/list-payment-refunds-request.md
+++ b/doc/models/list-payment-refunds-request.md
@@ -16,6 +16,9 @@ The maximum results per page is 100.
 |  --- | --- | --- | --- |
 | `BeginTime` | `string` | Optional | Indicates the start of the time range to retrieve each `PaymentRefund` for, in RFC 3339<br>format.  The range is determined using the `created_at` field for each `PaymentRefund`.<br><br>Default: The current time minus one year. |
 | `EndTime` | `string` | Optional | Indicates the end of the time range to retrieve each `PaymentRefund` for, in RFC 3339<br>format.  The range is determined using the `created_at` field for each `PaymentRefund`.<br><br>Default: The current time. |
+| `UpdatedAtBeginTime` | `string` | Optional | Indicates the start of the time range to retrieve each `PaymentRefund` for, in RFC 3339<br>format.  The range is determined using the `updated_at` field for each `PaymentRefund`.<br><br>Default: if omitted, the time range starts at `BeginTime`. |
+| `UpdatedAtEndTime` | `string` | Optional | Indicates the end of the time range to retrieve each `PaymentRefund` for, in RFC 3339<br>format.  The range is determined using the `updated_at` field for each `PaymentRefund`.<br><br>Default: The current time. |
+| `SortField` | `string` | Optional | The field used to sort results by. The default is `CREATED_AT`.<br>Current values include `CREATED_AT` and `UPDATED_AT`.<br> |
 | `SortOrder` | `string` | Optional | The order in which results are listed by `PaymentRefund.created_at`:<br><br>- `ASC` - Oldest to newest.<br>- `DESC` - Newest to oldest (default). |
 | `Cursor` | `string` | Optional | A pagination cursor returned by a previous call to this endpoint.<br>Provide this cursor to retrieve the next set of results for the original query.<br><br>For more information, see [Pagination](https://developer.squareup.com/docs/build-basics/common-api-patterns/pagination). |
 | `LocationId` | `string` | Optional | Limit results to the location supplied. By default, results are returned<br>for all locations associated with the seller. |


### PR DESCRIPTION
# **ATTENTION**
This repository **cannot** accept Pull Requests. If you wish to proceed with opening this PR, please understand that your code **will not** be pulled into this repository. Consider opening an issue which lays out the problem instead. Thank you very much for your efforts and highlighting issues!

Please direct all technical support questions, feature requests, API-related issues, and general discussions to our Square-supported developer channels. For public support, [join us in our Square Developer Discord server](https://discord.com/invite/squaredev) or [post in our Developer Forums](https://developer.squareup.com/forums). For private support, [contact our Developer Success Engineers](https://squareup.com/help/us/en/contact?panel=BF53A9C8EF68) directly.
