### PR TITLE
fix (deserialization): Fix issue where IEnumerable properties marked Readonly would not deserialize correctly.  Resulting in Location.Capabilities being empty

### DIFF
--- a/src/Square.Test/Integration/LocationsTests.cs
+++ b/src/Square.Test/Integration/LocationsTests.cs
@@ -23,5 +23,9 @@ public class LocationsTests
             Assert.That(response.Locations, Is.Not.Null);
             Assert.That(response.Locations, Is.Not.Empty);
         });
+        
+        var location = response.Locations.FirstOrDefault(l => l.Name!.Equals("Default Test Account"));
+        Assert.That(location, Is.Not.Null);
+        Assert.That(location.Capabilities, Is.Not.Null);
     }
 }

--- a/src/Square/Core/JsonConfiguration.cs
+++ b/src/Square/Core/JsonConfiguration.cs
@@ -47,7 +47,6 @@ internal static partial class JsonOptions
                                 switch (jsonAccessAttribute.AccessType)
                                 {
                                     case JsonAccessType.ReadOnly:
-                                        propertyInfo.Get = null;
                                         propertyInfo.ShouldSerialize = (_, _) => false;
                                         break;
                                     case JsonAccessType.WriteOnly:


### PR DESCRIPTION
Appreciate the disclaimer, just providing sample for #149 

# **ATTENTION**
This repository **cannot** accept Pull Requests. If you wish to proceed with opening this PR, please understand that your code **will not** be pulled into this repository. Consider opening an issue which lays out the problem instead. Thank you very much for your efforts and highlighting issues!

Please direct all technical support questions, feature requests, API-related issues, and general discussions to our Square-supported developer channels. For public support, [join us in our Square Developer Discord server](https://discord.com/invite/squaredev) or [post in our Developer Forums](https://developer.squareup.com/forums). For private support, [contact our Developer Success Engineers](https://squareup.com/help/us/en/contact?panel=BF53A9C8EF68) directly.
