### PR TITLE
ci: publish to NuGet via Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,4 +99,6 @@ jobs:
           user: ${{ secrets.NUGET_USER }}
 
       - name: Publish to nuget.org
-        run: dotnet nuget push dist/*.nupkg --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source "nuget.org" --skip-duplicate
+        env:
+          NUGET_API_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
+        run: dotnet nuget push dist/*.nupkg --api-key "$NUGET_API_KEY" --source "nuget.org" --skip-duplicate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,16 @@
+# Publishing uses nuget.org Trusted Publishing (OIDC) instead of a long-lived
+# API key. This workflow filename (ci.yml) is part of the trust-policy contract
+# on nuget.org -- do not rename it without updating the policy.
+#
+# Setup (one-time, on nuget.org):
+#   1. nuget.org -> user menu -> Trusted Publishing -> create policy.
+#   2. Repository Owner: square, Repository: square-dotnet-sdk,
+#      Workflow File: "ci.yml" (filename only, no path).
+#   3. Add a NUGET_USER repo secret containing your nuget.org profile name
+#      (not your email).
+#   4. After the first successful publish, remove the old NUGET_API_KEY secret
+#      (a stale key can interfere with OIDC login).
+
 name: CI
 
 on:
@@ -42,7 +55,6 @@ jobs:
         run: dotnet restore src/Square.sln
 
       - name: Build release
-        id: build
         run: dotnet build src/Square.sln -c Release /p:ContinuousIntegrationBuild=true
 
       - name: Run Tests
@@ -52,10 +64,39 @@ jobs:
           TEST_SQUARE_TOKEN: ${{ secrets.TEST_SQUARE_TOKEN }}
           TEST_SQUARE_REPORTING: ${{ secrets.TEST_SQUARE_REPORTING }}
 
+  publish:
+    needs: [ci]
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read    # Required for checkout
+      id-token: write   # Required for NuGet Trusted Publishing (OIDC)
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.x
+
+      - name: Install tools
+        run: dotnet tool restore
+
+      - name: Restore dependencies
+        run: dotnet restore src/Square.sln
+
+      - name: Build release
+        run: dotnet build src/Square.sln --no-restore -c Release /p:ContinuousIntegrationBuild=true
+
+      - name: Pack
+        run: dotnet pack src/Square.sln --no-build --no-restore -c Release -o dist
+
+      - name: NuGet login (OIDC -> temp API key)
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: Publish to nuget.org
-        if: github.event_name == 'push' && contains(github.ref, 'refs/tags/') && steps.build.outcome == 'success'
-        env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-        run: |
-          dotnet pack src/Square.sln --no-build --no-restore -c Release -o dist
-          dotnet nuget push dist/*.nupkg --api-key $NUGET_API_KEY --source "nuget.org"
+        run: dotnet nuget push dist/*.nupkg --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source "nuget.org" --skip-duplicate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
         run: dotnet pack src/Square.sln --no-build --no-restore -c Release -o dist
 
       - name: NuGet login (OIDC -> temp API key)
-        uses: NuGet/login@v1
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
         id: login
         with:
           user: ${{ secrets.NUGET_USER }}


### PR DESCRIPTION
## What

Switches NuGet publishing from a long-lived `NUGET_API_KEY` secret to **nuget.org Trusted Publishing (OIDC)**.

The inline `Publish to nuget.org` step is removed from the `ci` job and replaced with a dedicated `publish` job (`needs: [ci]`) that mints a short-lived key via `NuGet/login@v1` using a GitHub OIDC token.

## Why

The `NUGET_API_KEY` recently expired and blocked the `44.1.0-rc.0` publish. Trusted Publishing removes the long-lived secret entirely — keys are short-lived (~1h) and minted per-run, so there's nothing to store or rotate.

This mirrors the OIDC workflow now generated first-class by `fern-csharp-sdk` 2.69.0 ([fern-api/fern#16725](https://github.com/fern-api/fern/pull/16725)). The OIDC mechanics here are copied from that generator's output; the surrounding scaffold is kept aligned to this repo (solution build, dotnet 8.x, legacy-tag exclusions). Since `ci.yml` is in `.fernignore`, those customizations are preserved rather than regenerated away.

A separate `publish` job (vs. inlining into `ci`) deliberately scopes `id-token: write` to publishing only, keeping the OIDC mint permission off the job that runs test code.

## Required before this can publish

Done on **nuget.org** (repo admin / Square side):

1. nuget.org → user menu → **Trusted Publishing** → create policy:
   - **Repository Owner:** `square`
   - **Repository:** `square-dotnet-sdk`
   - **Workflow File:** `ci.yml` (filename only, no path)
2. Add a repo secret **`NUGET_USER`** = your nuget.org **profile name** (not email).
3. After the first successful publish, delete the old **`NUGET_API_KEY`** secret.

## Notes

- `ci.yml` filename is part of the trust-policy contract — renaming it requires updating the policy.
- `continue-on-error: true` on tests is preserved, so test failures still don't gate publishing (`needs: [ci]` proceeds because the `ci` job stays green).
- Legacy tags are already excluded at the `on:` trigger level, so the publish job's `if` needs no extra guard.
